### PR TITLE
[fix]: make the onHeightChange prop optional in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare module 'react-native-pell-rich-editor' {
         /**
          * Callback after height change
          */
-        onHeightChange: () => void;
+        onHeightChange?: () => void;
 
         /**
          * Styling for container or for Rich Editor more dark or light settings


### PR DESCRIPTION
not sure why it is made mandatory in the typescript declaration file. Not sure if its intentional or not.