### PR TITLE
Paste as plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ The editor component. Simply place this component in your view hierarchy to rece
 * `useContainer`
 
 	A boolean value that determines if a View container is wrapped around the WebView. The default value is true. If you are using your own View to wrap this library around, set this value to false. 
-	
-	
+
+* `pasteAsPlainText`
+
+	A boolean value (false as default) that determines if the clipboard paste will keep its format or it will be done as plain text
+
+
 `RichEditor` also has methods that can be used on its `ref` to  set:
 
 *  `setContentHTML(html: string)`

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -24,6 +24,7 @@ export default class RichTextEditor extends Component {
         initialFocus: false,
         disabled: false,
         useContainer: true,
+        pasteAsPlainText: false,
         editorInitializedCallback: () => {},
     };
 
@@ -40,9 +41,17 @@ export default class RichTextEditor extends Component {
         that.setRef = that.setRef.bind(that);
         that._keyOpen = false;
         that.selectionChangeListeners = [];
-        const {editorStyle: {backgroundColor, color, placeholderColor, cssText, contentCSSText} = {}, html} = props;
+        const {
+            editorStyle: {backgroundColor, color, placeholderColor, cssText, contentCSSText} = {},
+            html,
+            pasteAsPlainText,
+        } = props;
         that.state = {
-            html: {html: html || createHTML({backgroundColor, color, placeholderColor, cssText, contentCSSText})},
+            html: {
+                html:
+                    html ||
+                    createHTML({backgroundColor, color, placeholderColor, cssText, contentCSSText, pasteAsPlainText}),
+            },
             keyboardHeight: 0,
             height: 0,
             isInit: false,

--- a/src/editor.js
+++ b/src/editor.js
@@ -5,6 +5,7 @@ function createHTML(options = {}) {
         placeholderColor = '#a9a9a9',
         contentCSSText = '',
         cssText = '',
+        pasteAsPlainText = false,
     } = options;
     //ERROR: HTML height not 100%;
     return `
@@ -256,6 +257,16 @@ function createHTML(options = {}) {
             });
             addEventListener(content, 'focus', function () {
                 postAction({type: 'CONTENT_FOCUSED'});
+            });
+            ${pasteAsPlainText} && addEventListener(content, 'paste', function (e) {
+                // cancel paste
+                e.preventDefault();
+
+                // get text representation of clipboard
+                var text = (e.originalEvent || e).clipboardData.getData('text/plain');
+
+                // insert text manually
+                document.execCommand("insertHTML", false, text);
             });
 
             var message = function (event){


### PR DESCRIPTION
When pasting text into the editor sometimes it comes with a predefined format.

Usually from the website you can cmd+shift/ctrl+shif to paste as a plain text, but on the mobile app that is not possible.

On my case, I needed to be pasted as normal plaintext and then formatted on the editor if required.
So I have added a new `prop` named `pasteAsPlainText`.
This property, if defined it will force any clipboard paste as a plain text.
Left the default value as `false` to remain backwards compatible with current behaviour.