### PR TITLE
disabled editor height fix

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -63,7 +63,7 @@ function createHTML(options = {}) {
         };
 
         var postAction = function(data){
-            editor.content.contentEditable === 'true' && exports.window.postMessage(JSON.stringify(data));
+            (editor.content.contentEditable === 'true' || data.type === 'OFFSET_HEIGHT') && exports.window.postMessage(JSON.stringify(data));
         };
 
         console.log = function (){


### PR DESCRIPTION
When the editor starts with disabled=true and the height of the HTML is longer than the screen the height of the screen, the height does not updates.

This minor change fixes it.