### PR TITLE
Add `flatContainerStyle` to TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -266,6 +266,11 @@ export interface RichToolbarProps {
     style?: StyleProp<ViewStyle>;
 
     /**
+     * Flat container style prop for the toolbar
+     */
+    flatContainerStyle?: StyleProp<ViewStyle>;
+
+    /**
      * Your own set if images for the toolbar
      */
     iconMap?: Record<string, (IconRecord) => React.Element | ImageSourcePropType>;


### PR DESCRIPTION
TS typings do not have `flatContainerStyle` function which is legit API function.