### PR TITLE
Remove content autofocus causing initialFocus prop to be ignored

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -435,7 +435,6 @@ function createHTML(options = {}) {
             content.id = 'content';
             content.contentEditable = true;
             content.spellcheck = false;
-            content.autofocus = true;
             content.enterKeyHint = '${enterKeyHint}';
             content.autocapitalize = '${autoCapitalize}';
             content.autocorrect = ${autoCorrect};


### PR DESCRIPTION
Fixes #238

If the user wants the editor to autofocus, they can just provide `initialFocus={true}`.

Side note - I think there is a separate bug with `initialFocus={true}`. When I tested that out, occasionally my editor would automatically get blurred, even though I am not calling `blurContentEditor()` anywhere. It does seem to work most of the time though, and now after this PR, `initialFocus={false}` works as it should.