### PR TITLE
Scroll into view

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,11 @@ export class RichEditor extends React.Component<RichEditorProps> {
 
     focusContentEditor: () => void;
 
+    /**
+     * Scrolls the view into the current cursor position
+     */
+    scrollSelectionIntoView: () => void;
+
     insertImage: (attributes: any, style?: string) => void;
 
     insertVideo: (attributes: any, style?: string) => void;

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -346,6 +346,10 @@ export default class RichTextEditor extends Component {
         this.sendAction(actions.content, 'focus');
     }
 
+    scrollSelectionIntoView() {
+        this.sendAction(actions.content, 'scrollSelectionIntoView');
+    }
+
     /**
      * open android keyboard
      * @platform android

--- a/src/editor.js
+++ b/src/editor.js
@@ -201,6 +201,34 @@ function createHTML(options = {}) {
             focusOffset = sel.focusOffset;
         }
 
+        scrollSelectionIntoView = () => {
+            const selection = window.getSelection();
+
+            // Check if there are selection ranges
+            if (!selection.rangeCount) {
+                return;
+            }
+
+            // Get the first selection range. There's almost never can be more (instead of firefox)
+            const firstRange = selection.getRangeAt(0);
+
+            // Sometimes if the editable element is getting removed from the dom you may get a HierarchyRequest error in safari
+            if (firstRange.commonAncestorContainer === document) {
+                return;
+            }
+
+            const tempAnchorEl = document.createElement('div');
+            tempAnchorEl.style.height = '100px';
+
+            firstRange.insertNode(tempAnchorEl);
+
+            tempAnchorEl.scrollIntoView({
+                block: 'end',
+            });
+
+            tempAnchorEl.remove();
+        };
+
         function focusCurrent(){
             editor.content.focus();
             try {
@@ -218,6 +246,8 @@ function createHTML(options = {}) {
             } catch(e){
                 console.log(e)
             }
+            setTimeout(scrollSelectionIntoView, 250);
+            saveSelection();
         }
 
         var _keyDown = false;
@@ -366,6 +396,7 @@ function createHTML(options = {}) {
                 getHtml: function() { return editor.content.innerHTML; },
                 blur: function() { editor.content.blur(); },
                 focus: function() { focusCurrent(); },
+                scrollSelectionIntoView: function() { scrollSelectionIntoView(); },
                 postHtml: function (){ postAction({type: 'CONTENT_HTML_RESPONSE', data: editor.content.innerHTML}); },
                 setPlaceholder: function(placeholder){ editor.content.setAttribute("placeholder", placeholder) },
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -243,10 +243,12 @@ function createHTML(options = {}) {
                     selection.selectAllChildren(editor.content);
                     selection.collapseToEnd();
                 }
+
+                (!selection || selection.type == 'Caret') && setTimeout(scrollSelectionIntoView, 250);
+
             } catch(e){
                 console.log(e)
             }
-            setTimeout(scrollSelectionIntoView, 250);
             saveSelection();
         }
 
@@ -589,6 +591,8 @@ function createHTML(options = {}) {
                     // Set whether the checkbox is selected by default
                     if (ele.checked) ele.setAttribute('checked', '');
                     else ele.removeAttribute('checked');
+                } else {
+                    saveSelection();
                 }
             }
             addEventListener(content, 'touchcancel', handleSelecting);


### PR DESCRIPTION
When focusing the editor, if there's scrolling and the selection is below the scroll position (e.g., end), the current implementation will not adjust the scroll position to the caret position.

With this PR, I'm adding some code that will also scroll to the caret position using a hacky work-around found on stack overflow (https://stackoverflow.com/questions/47361276/javascript-scroll-to-cursor-post-a-paste-in-contenteditable-div).

Further, I'm also exposing the `scrollSelectionIntoView` method.

Lastly, I've also added missing calls to `saveSelection` so cursor state is always up to date.

@stulip please review and let me know your thoughts.