### PR TITLE
Fix nested tags when using p separator

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -340,11 +340,6 @@ function createHTML(options = {}) {
                     // title = title || window.prompt('Enter the link title');
                     var url = data.url || window.prompt('Enter the link URL');
                     if (url){
-                        // when adding a link, if our current node is empty, it may have a <br>
-                        // if so, replace it with '' so the added link doesn't end up with an extra space.
-                        if (anchorNode && anchorNode.innerHTML === '<br>') {
-                            anchorNode.innerHTML = '';
-                        }
                         exec('insertHTML', "<a href='"+ url +"'>"+(title || url)+"</a>");
                     }
                 }

--- a/src/editor.js
+++ b/src/editor.js
@@ -301,7 +301,7 @@ function createHTML(options = {}) {
 
                     let flag =  exec('insertUnorderedList');
                     adjustNestedElements();
-                    return flag
+                    return flag;
                 }
             },
             code: { result: function(type) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -340,6 +340,11 @@ function createHTML(options = {}) {
                     // title = title || window.prompt('Enter the link title');
                     var url = data.url || window.prompt('Enter the link URL');
                     if (url){
+                        // when adding a link, if our current node is empty, it may have a <br>
+                        // if so, replace it with '' so the added link doesn't end up with an extra space.
+                        if (anchorNode && anchorNode.innerHTML === '<br>') {
+                            anchorNode.innerHTML = '';
+                        }
                         exec('insertHTML', "<a href='"+ url +"'>"+(title || url)+"</a>");
                     }
                 }
@@ -483,7 +488,7 @@ function createHTML(options = {}) {
                         paragraphStatus = 1;
                     }
                 } else if (content.innerHTML === '<br>'){
-                     content.innerHTML = '';
+                    content.innerHTML = '';
                 } else if (enterStatus && queryCommandValue(formatBlock) === 'blockquote') {
                     formatParagraph();
                 }


### PR DESCRIPTION
When using <p> separators, `<ul>` and `<ol> `elements are currently nested inside `<p>`'s. However, this is incorrect HTML syntax and may break when using certain editors.

With this, after adding each ul/ol, a correction is made so nested tags are taken out to the parent. Code taken from https://developpaper.com/implementation-of-rich-text-editor-with-javascript/