### PR TITLE
Remove composition events that barely work on android

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -580,13 +580,16 @@ function createHTML(options = {}) {
                     exec("insertText", text);
                 }
             });
-            addEventListener(content, 'compositionstart', function(event){
-                compositionStatus = 1;
-            })
-            addEventListener(content, 'compositionend', function (event){
-                compositionStatus = 0;
-                paragraphStatus && formatParagraph(true);
-            })
+
+            // these make a mess on Android, and are not even used on iOS
+            // so it's better to disable them for now
+            // addEventListener(content, 'compositionstart', function(event){
+            //     compositionStatus = 1;
+            // })
+            // addEventListener(content, 'compositionend', function (event){
+            //     compositionStatus = 0;
+            //     paragraphStatus && formatParagraph(true);
+            // })
 
             var message = function (event){
                 var msgData = JSON.parse(event.data), action = Actions[msgData.type];


### PR DESCRIPTION
Thoughts on removing this? Composition events cause the following issues on Android:

- Tapping enter at the very beginning (empty html), will end up adding text like "mytext<div>another text</div>" instead of using divs at the beginning.
- It will also male ul/ol add extra spaces when tapping enter.

Note that tapping a space will "fix" this, but it would mean adding a space before every new line.