### PR TITLE
fix image insert

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -316,6 +316,8 @@ function createHTML(options = {}) {
                 result: function(url, style) {
                     if (url){
                         exec('insertHTML', "<img style='"+ (style || '')+"' src='"+ url +"'/>");
+                        // This is needed, or the image will not be inserted if the html is empty
+                        exec('insertHTML', "<br/>");
                         Actions.UPDATE_HEIGHT();
                     }
                 }


### PR DESCRIPTION
On iOS, if your html is empty and you call `insertImage`, it does nothing but adding an empty <br/> tag.

With this PR, we add an artificial break line after the image is inserted so the above is fixed.