### PR TITLE
Added an optional setting to disable symbols on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The editor component. Simply place this component in your view hierarchy to rece
 * `pasteAsPlainText`
     A boolean value (false as default) that determines if the clipboard paste will keep its format or it will be done as plain text
 
+* `useCharacter`
+  The option to disable Chinese characters allows you to support English characters without errors on Android. Set to `true` by default for backwards compatibility.
+
 * `onPaste`
   Callback clipboard paste value
 

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -57,6 +57,7 @@ export default class RichTextEditor extends Component {
       initialFocus,
       disabled,
       styleWithCSS,
+      useCharacter
     } = props;
     that.state = {
       html: {
@@ -83,6 +84,7 @@ export default class RichTextEditor extends Component {
             firstFocusEnd,
             useContainer,
             styleWithCSS,
+            useCharacter,
           }),
       },
       keyboardHeight: 0,

--- a/src/editor.js
+++ b/src/editor.js
@@ -41,6 +41,7 @@ function createHTML(options = {}) {
     firstFocusEnd = true,
     useContainer = true,
     styleWithCSS = false,
+    useCharacter = true,
   } = options;
   //ERROR: HTML height not 100%;
   return `
@@ -672,11 +673,15 @@ function createHTML(options = {}) {
                 }
             });
             addEventListener(content, 'compositionstart', function(event){
-                compositionStatus = 1;
+                if(useCharacter){
+                    compositionStatus = 1;
+                }
             })
             addEventListener(content, 'compositionend', function (event){
-                compositionStatus = 0;
-                paragraphStatus && formatParagraph(true);
+                if(useCharacter){
+                    compositionStatus = 0;
+                    paragraphStatus && formatParagraph(true);
+                }
             })
 
             var message = function (event){

--- a/src/editor.js
+++ b/src/editor.js
@@ -673,12 +673,12 @@ function createHTML(options = {}) {
                 }
             });
             addEventListener(content, 'compositionstart', function(event){
-                if(useCharacter){
+                if(${useCharacter}){
                     compositionStatus = 1;
                 }
             })
             addEventListener(content, 'compositionend', function (event){
-                if(useCharacter){
+                if(${useCharacter}){
                     compositionStatus = 0;
                     paragraphStatus && formatParagraph(true);
                 }


### PR DESCRIPTION

I modified the idea from this pull request #245 . The ability to work with Chinese characters has been preserved and a bug has been fixed when working with English characters.
Added an optional setting to disable Chinese characters.

Fix this:
1. Tapping enter at the very beginning (empty html), will end up adding text like "mytext another text" instead of using divs at the beginning.

1. It will also male ul/ol add extra spaces when tapping enter.