### PR TITLE
Props for manage FlatList style and direction

### DIFF
--- a/src/RichToolbar.js
+++ b/src/RichToolbar.js
@@ -259,13 +259,13 @@ export default class RichToolbar extends Component {
       <View style={vStyle}>
         <FlatList
           horizontal={horizontal}
+          style={flatContainerStyle}
           keyboardShouldPersistTaps={'always'}
           keyExtractor={(item, index) => item.action + '-' + index}
           data={this.state.data}
           alwaysBounceHorizontal={false}
           showsHorizontalScrollIndicator={false}
           renderItem={({item}) => this._renderAction(item.action, item.selected)}
-          contentContainerStyle={flatContainerStyle}
         />
         {children}
       </View>


### PR DESCRIPTION
My need was to add this editor to a flatlist and when the parent flatlist was set to "horizontal", the inner toolbar is shown vertically (known bug). So i've added two new props to change horizontal state and to add style to flatlist