### PR TITLE
fixed empty content handling causing formatting issues with compositionend

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -531,7 +531,7 @@ function createHTML(options = {}) {
             content.oninput = function (_ref) {
                 // var firstChild = _ref.target.firstChild;
                 if ((anchorNode === void 0 || anchorNode === content) && queryCommandValue(formatBlock) === ''){
-                    if ( !compositionStatus ){
+                    if ( !compositionStatus || anchorNode === content){
                         formatParagraph(true);
                         paragraphStatus = 0;
                     } else {


### PR DESCRIPTION
On Android I was having issues using lists, where deleting all text from the `content` and then typing was causing `paragraphStatus` to be permanently stuck at 1. This made the editor add extra divs on `compositionend`, resulting in new list items getting wrapped in a div in a separate list, causing extra space between list items, and li inside ol to be stuck at 1.

With this fix, the editor will detect when the `content` is empty/ user is typing directly into the `content` element, and format it accordingly. This also preserves `paragraphStatus` functionality.