### PR TITLE
Prepend https:// to links, optional but default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The editor component. Simply place this component in your view hierarchy to rece
 * `pasteAsPlainText`
     A boolean value (false as default) that determines if the clipboard paste will keep its format or it will be done as plain text
 
+* `defaultHttps`
+    A boolean value (true as default) that prepends https:// to the start of links
+
 * `onPaste`
   Callback clipboard paste value
 

--- a/src/RichEditor.js
+++ b/src/RichEditor.js
@@ -57,6 +57,7 @@ export default class RichTextEditor extends Component {
       initialFocus,
       disabled,
       styleWithCSS,
+      defaultHttps,
     } = props;
     that.state = {
       html: {
@@ -83,6 +84,7 @@ export default class RichTextEditor extends Component {
             firstFocusEnd,
             useContainer,
             styleWithCSS,
+            defaultHttps,
           }),
       },
       keyboardHeight: 0,

--- a/src/editor.js
+++ b/src/editor.js
@@ -41,6 +41,7 @@ function createHTML(options = {}) {
     firstFocusEnd = true,
     useContainer = true,
     styleWithCSS = false,
+    defaultHttps = true,
   } = options;
   //ERROR: HTML height not 100%;
   return `
@@ -354,8 +355,13 @@ function createHTML(options = {}) {
                     var url = data.url || window.prompt('Enter the link URL');
 
                     if (url) {
+                        let href = url
+                        if (${defaultHttps} && !href.startsWith("http")) {
+                            href = "https://" + href
+                        }
+
                         var el = document.createElement("a");
-                        el.setAttribute("href", url);
+                        el.setAttribute("href", href);
 
                         var title = data.title || sel.toString() || url;
                         el.text = title;


### PR DESCRIPTION
I was having issues with this with composing emails and patching the repo with this fixed it.

This could be flipped to false as default if there's a concern about pushing a potentially breaking change for others, it just made sense to me at least for it to be on by default.