### PR TITLE
fix broken check box action usage

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -245,10 +245,7 @@ function createHTML(options = {}) {
                     var br = createElement('br');
                     sp.appendChild(br);
                     setTimeout(function (){
-                        if (!node.classList.contains("x-todo-box")){
-                            node = node.parentNode.previousSibling;
-                        }
-                        node.parentNode.replaceChild(sp, node);
+                        node.replaceChild(sp, node.lastElementChild);
                         setCollapse(sp);
                     });
                 }
@@ -441,11 +438,12 @@ function createHTML(options = {}) {
                     if (anchorNode === editor.content || queryCommandValue(formatBlock) === ''){
                         formatParagraph();
                     }
+                    
                     var box = checkboxNode(anchorNode);
                     if (!!box){
                         cancelCheckboxList(box.parentNode);
                     } else {
-                        !queryCommandState('insertOrderedList') && execCheckboxList(pNode);
+                        !queryCommandState('insertOrderedList') && execCheckboxList(anchorNode);
                     }
                 }
             },


### PR DESCRIPTION
This pr fixes the issue: https://github.com/wxik/react-native-rich-editor/issues/232

Currently the checkbox action is not work well. It breaks the content when you add a checkbox and add new lines.

I add broken example screenshots and fixed one.

Here is the broken one, it is trying to include every content in the html:
![image](https://github.com/user-attachments/assets/3efa22c4-a565-4aba-bbc6-33745da17c5f)

Broken on new line:
![image](https://github.com/user-attachments/assets/c0cb5ce7-8aec-421c-8df5-855ff18dec73)

Fixed version:
![image](https://github.com/user-attachments/assets/b818fa40-54a7-4135-9fbf-f4c4a8d008cb)
